### PR TITLE
File Transfer Logging

### DIFF
--- a/lib/session.py
+++ b/lib/session.py
@@ -5,6 +5,7 @@ import paramiko
 import hashlib
 from termcolor import colored, cprint
 
+
 class Session(object):
     """Session will take care of all the backend communications."""
 


### PR DESCRIPTION
Log path and sha256 hash of files transmitted to remote host. 

Errors in __log_file_details are logged as warnings, in the console and log file, because this function is non-critical to successful memory extraction.
